### PR TITLE
fix: updates to clap 3.0.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,8 +10,8 @@ utils = { path = "../utils" }
 core = { path = "../core" }
 
 [dependencies.clap]
-version = "3.0.0-beta.2"
-features = ["yaml"]
+version = "3.0.0"
+features = ["cargo"]
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,11 +46,10 @@ pub fn cli_config() -> Result<clap::ArgMatches> {
                 .short('c')
                 .long("config")
                 .value_name("FILE")
-                .about("Set a custom config file")
+                .help("Set a custom config file")
                 .takes_value(true),
         )
         .subcommand(App::new("hazard").about("Generate a hazardous occurance"))
-
         .subcommand(App::new("error").about("Simulate an error"))
         .subcommand(App::new("config").about("Show Configuration"));
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,3 @@ utils = { path = "../utils" }
 
 rand = "0.7.3"
 log = "0.4.11"
-
-[dependencies.clap]
-version = "3.0.0-beta.2"
-features = ["yaml"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,7 +17,4 @@ slog-async = "2.5.0"
 slog-stdlog = "4.1.0"
 log = "0.4.11"
 serde = { version = "1.0", features = ["derive"]}
-
-[dependencies.clap]
-version = "3.0.0-beta.2"
-features = ["yaml"]
+clap = "3.0.0"


### PR DESCRIPTION
the project does not currently compile without either fixing  clap = "=3.0.0.beta.2" or conforming to new clap options.