### PR TITLE
Fix MacOS Compilation

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -23,7 +23,8 @@ slog-term = "2.9.0"
 slog-scope = "4.4.0"
 slog-async = "2.8.0"
 slog-stdlog = "4.1.1"
-slog-journald = "2.2.0"
 clap = "4.4.7"
 log = "0.4.20"
 serde = { version = "1.0.192", features = ["derive"] }
+[target.'cfg(target_os = "linux")'.dependencies]
+slog-journald = "2.2.0"

--- a/utils/src/logger.rs
+++ b/utils/src/logger.rs
@@ -1,5 +1,6 @@
 use slog::o;
 use slog::Drain;
+#[cfg(target_os = "linux")]
 use slog_journald::JournaldDrain;
 use slog_syslog::Facility;
 
@@ -23,6 +24,7 @@ pub fn default_root_logger() -> Result<slog::Logger> {
     #[cfg(feature = "syslog")]
     let drain = slog::Duplicate(default_syslog_drain().unwrap_or(default_discard()?), drain).fuse();
     #[cfg(feature = "journald")]
+    #[cfg(target_os = "linux")]
     let drain = slog::Duplicate(
         default_journald_drain().unwrap_or(default_discard()?),
         drain,
@@ -61,6 +63,7 @@ fn default_syslog_drain() -> Result<slog_async::Async> {
     Ok(drain)
 }
 
+#[cfg(target_os = "linux")]
 fn default_journald_drain() -> Result<slog_async::Async> {
     let journald = JournaldDrain.ignore_res();
     let drain = slog_async::Async::default(journald);


### PR DESCRIPTION
Addresses issue https://github.com/rust-starter/rust-starter/issues/48

Makes dependency `slog-journald` only for Linux